### PR TITLE
feat: add delete endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,9 @@
 
 from flask import Flask, jsonify, request
 from pathlib import Path
-import json, os, time
+import json
+import os
+import time
 
 app = Flask(__name__)
 DATA_PATH = Path("prompts/sample.json")
@@ -70,6 +72,17 @@ def update_prompt(pid):
             it["updated_at"] = now_iso()
             save_data(items)
             return jsonify(it)
+    return jsonify({"error": "not found"}), 404
+
+
+@app.delete("/prompts/<pid>")
+def delete_prompt(pid):
+    items = load_data()
+    for idx, it in enumerate(items):
+        if it["id"] == pid:
+            items.pop(idx)
+            save_data(items)
+            return jsonify({"status": "deleted"})
     return jsonify({"error": "not found"}), 404
 
 if __name__ == "__main__":

--- a/spec.md
+++ b/spec.md
@@ -11,7 +11,7 @@
 - `GET /prompts/<id>` → einzelner Prompt
 - `POST /prompts` → `{ title, body, tags?[] }` → erstellt, gibt `id` zurück
 - `PUT /prompts/<id>` → ersetzt Felder
-- (später) `DELETE /prompts/<id>`
+- `DELETE /prompts/<id>` → löscht einen Prompt
 
 ## Datenformat
 ```json

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import app as pv
+
+
+def test_delete_prompt(tmp_path, monkeypatch):
+    data_file = tmp_path / "data.json"
+    monkeypatch.setattr(pv, "DATA_PATH", data_file)
+    data_file.parent.mkdir(parents=True, exist_ok=True)
+    data_file.write_text("[]", encoding="utf-8")
+    client = pv.app.test_client()
+
+    res = client.post("/prompts", json={"title": "T", "body": "B"})
+    pid = res.get_json()["id"]
+
+    res = client.delete(f"/prompts/{pid}")
+    assert res.status_code == 200
+    assert res.get_json()["status"] == "deleted"
+
+    res = client.get(f"/prompts/{pid}")
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- add `DELETE /prompts/<id>` endpoint to remove prompts from storage
- document delete endpoint in spec
- test delete operation using Flask test client

## Testing
- `ruff check app.py tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbe994b3d48324b78cd8c402124d03