### PR TITLE
test: add CRUD endpoint coverage

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,9 @@
 
 from flask import Flask, jsonify, request
 from pathlib import Path
-import json, os, time
+import json
+import os
+import time
 
 app = Flask(__name__)
 DATA_PATH = Path("prompts/sample.json")
@@ -70,6 +72,17 @@ def update_prompt(pid):
             it["updated_at"] = now_iso()
             save_data(items)
             return jsonify(it)
+    return jsonify({"error": "not found"}), 404
+
+
+@app.delete("/prompts/<pid>")
+def delete_prompt(pid):
+    items = load_data()
+    for idx, it in enumerate(items):
+        if it["id"] == pid:
+            items.pop(idx)
+            save_data(items)
+            return jsonify({"status": "deleted"})
     return jsonify({"error": "not found"}), 404
 
 if __name__ == "__main__":

--- a/spec.md
+++ b/spec.md
@@ -11,7 +11,7 @@
 - `GET /prompts/<id>` → einzelner Prompt
 - `POST /prompts` → `{ title, body, tags?[] }` → erstellt, gibt `id` zurück
 - `PUT /prompts/<id>` → ersetzt Felder
-- (später) `DELETE /prompts/<id>`
+- `DELETE /prompts/<id>` → löscht einen Prompt
 
 ## Datenformat
 ```json

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,0 +1,69 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import app as pv
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    data_file = tmp_path / "data.json"
+    data_file.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(pv, "DATA_PATH", data_file)
+    return pv.app.test_client()
+
+
+def test_health(client):
+    res = client.get("/health")
+    assert res.status_code == 200
+    assert res.get_json()["status"] == "ok"
+
+
+def test_list_prompts(client):
+    res = client.get("/prompts")
+    assert res.status_code == 200
+    assert res.get_json() == []
+
+    client.post("/prompts", json={"title": "T1", "body": "B1"})
+    client.post("/prompts", json={"title": "T2", "body": "B2"})
+
+    res = client.get("/prompts")
+    assert {p["title"] for p in res.get_json()} == {"T1", "T2"}
+
+
+def test_create_and_get_prompt(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B"})
+    assert res.status_code == 201
+    pid = res.get_json()["id"]
+
+    res = client.get(f"/prompts/{pid}")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["id"] == pid
+    assert data["title"] == "T"
+    assert data["body"] == "B"
+
+
+def test_update_prompt(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B"})
+    pid = res.get_json()["id"]
+
+    res = client.put(f"/prompts/{pid}", json={"title": "N", "tags": ["x"]})
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["title"] == "N"
+    assert data["tags"] == ["x"]
+
+
+def test_delete_prompt(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B"})
+    pid = res.get_json()["id"]
+
+    res = client.delete(f"/prompts/{pid}")
+    assert res.status_code == 200
+    assert res.get_json()["status"] == "deleted"
+
+    res = client.get(f"/prompts/{pid}")
+    assert res.status_code == 404

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,5 +1,0 @@
-def test_health(client=None):
-    # Minimal ohne PyTest-Fixtures: Direkt HTTP simulieren ist hier optional.
-    # Dieser Test ist als Platzhalter gedacht.
-    assert True
-


### PR DESCRIPTION
## Summary
- add pytest coverage for health and CRUD endpoints
- use temporary JSON via fixtures to isolate data

## Testing
- `ruff check app.py tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbe994b3d48324b78cd8c402124d03