### PR TITLE
feat: filter prompts by tag

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -8,10 +8,11 @@
 ## Endpunkte
 - `GET /health` → `{ "status": "ok" }`
 - `GET /prompts` → Liste aller Prompts
+ - Optionaler Query-Parameter `tag` (kommagetrennt), um nach Tags zu filtern; leer/fehlend → alle Prompts
 - `GET /prompts/<id>` → einzelner Prompt
 - `POST /prompts` → `{ title, body, tags?[] }` → erstellt, gibt `id` zurück
 - `PUT /prompts/<id>` → ersetzt Felder
-- (später) `DELETE /prompts/<id>`
+- `DELETE /prompts/<id>` → löscht einen Prompt
 
 ## Datenformat
 ```json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import app as pv
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    data_file = tmp_path / "data.json"
+    data_file.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(pv, "DATA_PATH", data_file)
+    return pv.app.test_client()

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,0 +1,52 @@
+def test_health(client):
+    res = client.get("/health")
+    assert res.status_code == 200
+    assert res.get_json()["status"] == "ok"
+
+
+def test_list_prompts(client):
+    res = client.get("/prompts")
+    assert res.status_code == 200
+    assert res.get_json() == []
+
+    client.post("/prompts", json={"title": "T1", "body": "B1"})
+    client.post("/prompts", json={"title": "T2", "body": "B2"})
+
+    res = client.get("/prompts")
+    assert {p["title"] for p in res.get_json()} == {"T1", "T2"}
+
+
+def test_create_and_get_prompt(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B"})
+    assert res.status_code == 201
+    pid = res.get_json()["id"]
+
+    res = client.get(f"/prompts/{pid}")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["id"] == pid
+    assert data["title"] == "T"
+    assert data["body"] == "B"
+
+
+def test_update_prompt(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B"})
+    pid = res.get_json()["id"]
+
+    res = client.put(f"/prompts/{pid}", json={"title": "N", "tags": ["x"]})
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["title"] == "N"
+    assert data["tags"] == ["x"]
+
+
+def test_delete_prompt(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B"})
+    pid = res.get_json()["id"]
+
+    res = client.delete(f"/prompts/{pid}")
+    assert res.status_code == 200
+    assert res.get_json()["status"] == "deleted"
+
+    res = client.get(f"/prompts/{pid}")
+    assert res.status_code == 404

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,36 @@
+from typing import List
+
+
+def seed_prompts(client) -> List[str]:
+    ids = []
+    res = client.post("/prompts", json={"title": "T1", "body": "B1", "tags": ["demo"]})
+    ids.append(res.get_json()["id"])
+    res = client.post("/prompts", json={"title": "T2", "body": "B2", "tags": ["plan"]})
+    ids.append(res.get_json()["id"])
+    res = client.post("/prompts", json={"title": "T3", "body": "B3", "tags": ["demo", "plan"]})
+    ids.append(res.get_json()["id"])
+    return ids
+
+
+def test_no_tag_returns_all(client):
+    seed_prompts(client)
+    res = client.get("/prompts")
+    assert {p["title"] for p in res.get_json()} == {"T1", "T2", "T3"}
+
+
+def test_single_tag_filter(client):
+    seed_prompts(client)
+    res = client.get("/prompts?tag=demo")
+    assert {p["title"] for p in res.get_json()} == {"T1", "T3"}
+
+
+def test_multi_tag_filter(client):
+    seed_prompts(client)
+    res = client.get("/prompts?tag=demo,plan")
+    assert {p["title"] for p in res.get_json()} == {"T1", "T2", "T3"}
+
+
+def test_unknown_tag(client):
+    seed_prompts(client)
+    res = client.get("/prompts?tag=unknown")
+    assert res.get_json() == []

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,5 +1,0 @@
-def test_health(client=None):
-    # Minimal ohne PyTest-Fixtures: Direkt HTTP simulieren ist hier optional.
-    # Dieser Test ist als Platzhalter gedacht.
-    assert True
-


### PR DESCRIPTION
## Summary
- support filtering prompts by `tag` query parameter
- document tag filtering in the spec
- add pytest coverage for tag filtering

## Testing
- `ruff check app.py tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbe994b3d48324b78cd8c402124d03