### PR TITLE
Add prompt version history support

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,15 @@ def get_prompt(pid):
             return jsonify(it)
     return jsonify({"error": "not found"}), 404
 
+
+@app.get("/prompts/<pid>/history")
+def get_history(pid):
+    items = load_data()
+    for it in items:
+        if it["id"] == pid:
+            return jsonify(it.get("history", []))
+    return jsonify({"error": "not found"}), 404
+
 @app.post("/prompts")
 def create_prompt():
     body = request.get_json(force=True, silent=True) or {}
@@ -61,6 +70,7 @@ def create_prompt():
         "tags": tags,
         "created_at": now_iso(),
         "updated_at": now_iso(),
+        "history": [],
     }
     items.append(item)
     save_data(items)
@@ -72,9 +82,18 @@ def update_prompt(pid):
     items = load_data()
     for it in items:
         if it["id"] == pid:
+            prev = {
+                "title": it["title"],
+                "body": it["body"],
+                "updated_at": it.get("updated_at") or now_iso(),
+            }
+            if "tags" in it:
+                prev["tags"] = list(it.get("tags", []))
+            it.setdefault("history", []).append(prev)
+
             it["title"] = body.get("title", it["title"])
-            it["body"]  = body.get("body", it["body"])
-            it["tags"]  = body.get("tags", it["tags"])
+            it["body"] = body.get("body", it["body"])
+            it["tags"] = body.get("tags", it.get("tags"))
             it["updated_at"] = now_iso()
             save_data(items)
             return jsonify(it)

--- a/spec.md
+++ b/spec.md
@@ -10,6 +10,7 @@
 - `GET /prompts` → Liste aller Prompts
  - Optionaler Query-Parameter `tag` (kommagetrennt), um nach Tags zu filtern; leer/fehlend → alle Prompts
 - `GET /prompts/<id>` → einzelner Prompt
+- `GET /prompts/<id>/history` → Liste früherer Versionen
 - `POST /prompts` → `{ title, body, tags?[] }` → erstellt, gibt `id` zurück
 - `PUT /prompts/<id>` → ersetzt Felder
 - `DELETE /prompts/<id>` → löscht einen Prompt
@@ -22,5 +23,13 @@
   "body": "Lies README, erstelle Plan, implementiere Schritt 1...",
   "tags": ["dev","plan"],
   "created_at": "2025-09-06T06:00:00Z",
-  "updated_at": "2025-09-06T06:00:00Z"
+  "updated_at": "2025-09-06T06:00:00Z",
+  "history": [
+    {
+      "title": "Bugfix-Plan",
+      "body": "Lies README, erstelle Plan, implementiere Schritt 1...",
+      "tags": ["dev","plan"],
+      "updated_at": "2025-09-06T05:00:00Z"
+    }
+  ]
 }

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -63,4 +63,4 @@ def test_delete_prompt(client):
 
     res = client.delete(f"/prompts/{pid}")
     assert res.status_code == 200
-    assert res.get
+    assert res.get_json()["status"] == "deleted"

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,40 @@
+import pytest
+
+
+def test_update_creates_history_entry(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B", "tags": ["x"]})
+    pid = res.get_json()["id"]
+
+    res = client.get(f"/prompts/{pid}/history")
+    assert res.status_code == 200
+    assert res.get_json() == []
+
+    res = client.put(f"/prompts/{pid}", json={"title": "N"})
+    assert res.status_code == 200
+
+    res = client.get(f"/prompts/{pid}/history")
+    history = res.get_json()
+    assert len(history) == 1
+    entry = history[0]
+    assert entry["title"] == "T"
+    assert entry["body"] == "B"
+    assert entry["tags"] == ["x"]
+    assert "updated_at" in entry
+
+
+def test_history_returns_versions(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B", "tags": ["a"]})
+    pid = res.get_json()["id"]
+
+    client.put(f"/prompts/{pid}", json={"title": "N"})
+    client.put(f"/prompts/{pid}", json={"body": "C", "tags": ["b"]})
+
+    res = client.get(f"/prompts/{pid}/history")
+    history = res.get_json()
+    assert len(history) == 2
+    assert history[0]["title"] == "T"
+    assert history[0]["body"] == "B"
+    assert history[0]["tags"] == ["a"]
+    assert history[1]["title"] == "N"
+    assert history[1]["body"] == "B"
+    assert history[1]["tags"] == ["a"]


### PR DESCRIPTION
## Summary
- store previous prompt versions in a `history` array and expose a `/prompts/<id>/history` endpoint
- document history support in the spec
- test that updates create history entries and that history retrieval works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc4668d0508324870a299e2e8bd80c