### PR TITLE
Add prompt version history support

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -10,6 +10,8 @@
 - `GET /prompts` → Liste aller Prompts
  - Optionaler Query-Parameter `tag` (kommagetrennt), um nach Tags zu filtern; leer/fehlend → alle Prompts
 - `GET /prompts/<id>` → einzelner Prompt
+- `GET /prompts/<id>/history` → Liste früherer Versionen; optional `?limit=n` → letzte n Einträge
+- `GET /prompts/<id>/history/<version>` → einzelne Version nach Index (0 = älteste, -1 = neueste)
 - `POST /prompts` → `{ title, body, tags?[] }` → erstellt, gibt `id` zurück
 - `PUT /prompts/<id>` → ersetzt Felder
 - `DELETE /prompts/<id>` → löscht einen Prompt
@@ -22,5 +24,14 @@
   "body": "Lies README, erstelle Plan, implementiere Schritt 1...",
   "tags": ["dev","plan"],
   "created_at": "2025-09-06T06:00:00Z",
-  "updated_at": "2025-09-06T06:00:00Z"
+  "updated_at": "2025-09-06T06:00:00Z",
+  "history": [
+    {
+      "title": "Bugfix-Plan",
+      "body": "Lies README, erstelle Plan, implementiere Schritt 1...",
+      "tags": ["dev","plan"],
+      "updated_at": "2025-09-06T05:00:00Z"
+    }
+  ]
 }
+```

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -63,4 +63,4 @@ def test_delete_prompt(client):
 
     res = client.delete(f"/prompts/{pid}")
     assert res.status_code == 200
-    assert res.get
+    assert res.get_json()["status"] == "deleted"

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,73 @@
+import pytest
+
+
+def test_update_creates_history_entry(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B", "tags": ["x"]})
+    pid = res.get_json()["id"]
+
+    res = client.get(f"/prompts/{pid}/history")
+    assert res.status_code == 200
+    assert res.get_json() == []
+
+    res = client.put(f"/prompts/{pid}", json={"title": "N"})
+    assert res.status_code == 200
+
+    res = client.get(f"/prompts/{pid}/history")
+    history = res.get_json()
+    assert len(history) == 1
+    entry = history[0]
+    assert entry["title"] == "T"
+    assert entry["body"] == "B"
+    assert entry["tags"] == ["x"]
+    assert "updated_at" in entry
+
+
+def test_two_updates_create_two_entries(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B"})
+    pid = res.get_json()["id"]
+
+    client.put(f"/prompts/{pid}", json={"title": "N1"})
+    client.put(f"/prompts/{pid}", json={"body": "C"})
+
+    res = client.get(f"/prompts/{pid}/history")
+    history = res.get_json()
+    assert len(history) == 2
+
+
+def test_get_history_version(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B", "tags": ["a"]})
+    pid = res.get_json()["id"]
+
+    client.put(f"/prompts/{pid}", json={"title": "N1"})
+    client.put(f"/prompts/{pid}", json={"body": "C"})
+
+    res = client.get(f"/prompts/{pid}/history/0")
+    entry = res.get_json()
+    assert entry["title"] == "T"
+    assert entry["body"] == "B"
+    assert entry["tags"] == ["a"]
+
+
+def test_history_version_invalid_index(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B"})
+    pid = res.get_json()["id"]
+    client.put(f"/prompts/{pid}", json={"title": "N"})
+
+    res = client.get(f"/prompts/{pid}/history/5")
+    assert res.status_code == 404
+
+
+def test_history_limit_parameter(client):
+    res = client.post("/prompts", json={"title": "T", "body": "B", "tags": ["a"]})
+    pid = res.get_json()["id"]
+
+    client.put(f"/prompts/{pid}", json={"title": "N1"})
+    client.put(f"/prompts/{pid}", json={"body": "C"})
+
+    res = client.get(f"/prompts/{pid}/history?limit=1")
+    history = res.get_json()
+    assert len(history) == 1
+    entry = history[0]
+    assert entry["title"] == "N1"
+    assert entry["body"] == "B"
+    assert entry["tags"] == ["a"]


### PR DESCRIPTION
## Summary
- add ability to fetch a single history version via `/prompts/<id>/history/<version>`
- allow limiting history results with `?limit=n`
- test multiple updates, version lookup, invalid indexes, and limit filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc4668d0508324870a299e2e8bd80c